### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,0 +1,42 @@
+name: Deploy Jupyter Book
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install jupyter-book
+
+    - name: Build the book
+      run: |
+        jupyter-book build .
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+      
+    - name: Upload to GitHub Pages
+      uses: actions/upload-pages-artifact@v2
+      with:
+        path: ./_build/html
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
-jupyter-book
-matplotlib
-numpy
+jupyter-book>=1.0.0
+matplotlib>=3.5.0
+numpy>=1.21.0
+pandas>=1.3.0
+plotly>=5.0.0
+yfinance>=0.1.70


### PR DESCRIPTION
- Created GitHub Actions workflow for automatic Jupyter Book deployment
- Updated requirements.txt with ETF analysis dependencies (pandas, yfinance, plotly)
- Workflow triggers on pushes to main branch and builds/deploys book to GitHub Pages
- Includes proper permissions and uses latest GitHub Actions

Link to Devin run: https://app.devin.ai/sessions/b78acac32b8849adb2e24a979fc313e8
Requested by: nairrak (rakesh.s.nair@gmail.com)